### PR TITLE
[feature] To not use namespace librados function, so downgrade to 0.93.

### DIFF
--- a/php_rados.h
+++ b/php_rados.h
@@ -2,7 +2,7 @@
 #define PHP_RADOS_H
 
 #define PHP_RADOS_EXTNAME  "rados"
-#define PHP_RADOS_EXTVER   "0.9.4"
+#define PHP_RADOS_EXTVER   "0.9.3"
 
 #include "php.h"
 #include "php_ini.h"
@@ -29,7 +29,6 @@ typedef struct _php_rados_cluster {
 
 typedef struct _php_rados_ioctx {
     rados_ioctx_t io;
-    char *nspace;
 } php_rados_ioctx;
 
 //aio
@@ -88,8 +87,6 @@ PHP_FUNCTION(rados_get_instance_id);
 //PHP_FUNCTION(rados_ioctx_create2);
 PHP_FUNCTION(rados_ioctx_get_id);
 PHP_FUNCTION(rados_ioctx_get_pool_name);
-PHP_FUNCTION(rados_ioctx_get_namespace);
-PHP_FUNCTION(rados_ioctx_set_namespace);
 
 //aio
 PHP_FUNCTION(rados_aio_create_completion);

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -1,4 +1,3 @@
-<?php
 /*
  * phprados - A PHP5 extension for using librados
  *
@@ -10,6 +9,8 @@
  * Foundation.  See file COPYING.
  *
  */
+
+<?php
 
 class RadosTest extends PHPUnit_Framework_TestCase {
 
@@ -206,7 +207,6 @@ class RadosTest extends PHPUnit_Framework_TestCase {
     public function testRadosClusterFsid($cluster) {
         $fsid = rados_cluster_fsid($cluster);
         $this->assertEquals(36, strlen($fsid));
-        $this->assertEquals(1, preg_match('/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/', $fsid));
     }
 
     /**
@@ -221,18 +221,6 @@ class RadosTest extends PHPUnit_Framework_TestCase {
      */
     public function testRadosShutDown($cluster) {
         $this->assertTrue(rados_shutdown($cluster));
-    }
-
-    /**
-     * @depends testRadosCreateIoCTX
-     */
-    public function testRadosNamespace($ioctx) {
-        $this->assertNull(rados_ioctx_get_namespace($ioctx));
-        rados_ioctx_set_namespace($ioctx, "foo");
-        $name = rados_ioctx_get_namespace($ioctx);
-        $this->assertEquals($name, "foo");
-        rados_ioctx_set_namespace($ioctx, NULL);
-        $this->assertNull(rados_ioctx_get_namespace($ioctx));
     }
 }
 


### PR DESCRIPTION
Revert "Implement rados_ioctx_get_pool_name"

This reverts commit a9bdd8cf10f561b8d91e6c5fe21ba3e8df412bbb.

Conflicts:
    php_rados.h
    rados.c
